### PR TITLE
[codex] Fix PR review import robustness

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: "3.11"
     - name: Install build and create dist

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install amazon-to-sqlite
 ## Usage
 
 Import one or more CSV files — or point it at the unzipped export directory
-and it will find every CSV in there:
+and it will find every `.csv`/`.CSV` file in there:
 
 ```bash
 amazon-to-sqlite import Retail.OrderHistory.1.csv
@@ -68,8 +68,9 @@ and rate-limits automated requests.
 - `Not Applicable` / `Not Available` values are stored as `NULL`.
 - Column headers are matched **by name**, so Amazon reordering or adding
   columns won't corrupt an import; a missing expected column fails loudly.
-- Indexes are created on `Order_Date`, `ASIN` and `Order_Status`, plus a
-  full-text search index on `Product_Name` (`amazon_orders_fts`).
+- Indexes are created on `Order_Date`, `ASIN` and `Order_Status`. When the
+  local SQLite build includes FTS5, a full-text search index is also created on
+  `Product_Name` (`amazon_orders_fts`).
 
 ## Exploring with Datasette
 
@@ -79,8 +80,8 @@ datasette amazon.db -m metadata.json
 ```
 
 The bundled [`metadata.json`](metadata.json) includes canned queries such as
-spend by year, spend by month, top products, and orders by status. Full-text
-search product names with:
+spend by year, spend by month, top products, and orders by status. When FTS5 is
+available, full-text search product names with:
 
 ```sql
 SELECT * FROM amazon_orders

--- a/amazon_to_sqlite/__main__.py
+++ b/amazon_to_sqlite/__main__.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import sqlite3
 import sys
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -82,6 +84,12 @@ def build_parser() -> argparse.ArgumentParser:
         default=DEFAULT_DB,
         help=f"SQLite database file (default: {DEFAULT_DB})",
     )
+    formats_parser.add_argument(
+        "--delay",
+        type=float,
+        default=1.0,
+        help="Seconds to wait between Amazon requests (default: 1.0)",
+    )
     return parser
 
 
@@ -111,7 +119,13 @@ def _import_command(args: argparse.Namespace) -> int:
                     exit_code,
                     _import_one(conn, csv_path, args, dropped),
                 )
-            except (EmptyCsvError, HeaderMismatchError, OSError) as exc:
+            except (
+                csv.Error,
+                EmptyCsvError,
+                HeaderMismatchError,
+                OSError,
+                sqlite3.Error,
+            ) as exc:
                 print(f"{csv_path}: {exc}", file=sys.stderr)
                 exit_code = 1
     finally:
@@ -132,11 +146,12 @@ def _import_one(
 
     bar = tqdm(desc=csv_path.name, unit=" rows") if not args.quiet else None
     try:
-        result = import_file(
-            conn,
-            csv_path,
-            progress=bar.update if bar is not None else None,
-        )
+        with conn:
+            result = import_file(
+                conn,
+                csv_path,
+                progress=bar.update if bar is not None else None,
+            )
     finally:
         if bar is not None:
             bar.close()
@@ -155,6 +170,10 @@ def _import_one(
 
 
 def _check_formats_command(args: argparse.Namespace) -> int:
+    if args.delay < 0:
+        print("--delay must be non-negative", file=sys.stderr)
+        return 1
+
     if args.asins:
         books = [{"asin": asin, "title": ""} for asin in args.asins]
     else:
@@ -168,18 +187,23 @@ def _check_formats_command(args: argparse.Namespace) -> int:
         conn = _connect(args.db)
         try:
             books = db.get_books(conn)
+        except sqlite3.Error as exc:
+            print(f"{args.db}: {exc}", file=sys.stderr)
+            return 1
         finally:
             conn.close()
         if not books:
             print("No print books (ISBN-10 ASINs) found in the database.")
             return 0
 
-    for book in books:
+    for position, book in enumerate(books):
         if book["title"]:
             print(f"\n{book['title']} ({book['asin']})")
         else:
             print(f"\n{book['asin']}")
         check_book_formats(book["asin"])
+        if args.delay > 0 and position < len(books) - 1:
+            time.sleep(args.delay)
     return 0
 
 

--- a/amazon_to_sqlite/db.py
+++ b/amazon_to_sqlite/db.py
@@ -43,11 +43,14 @@ MISSING_VALUES = ("Not Applicable", "Not Available")
 
 ISBN10_LENGTH = 10
 
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
 
 def sanitize_name(name: str) -> str:
     """Turn an arbitrary string into a safe SQLite identifier."""
     safe = "".join(
-        c if c.isalnum() or c == "_" else "_" for c in name.replace(" ", "_")
+        c if c.isascii() and (c.isalnum() or c == "_") else "_"
+        for c in name.replace(" ", "_")
     )
     safe = re.sub(r"_+", "_", safe).strip("_")
     if not safe or safe[0].isdigit():
@@ -60,6 +63,18 @@ FIELDS = [sanitize_name(field) for field in FIELD_TYPES]
 INDEXED_FIELDS = ("Order_Date", "ASIN", "Order_Status")
 
 
+def _safe_identifier(name: str) -> str:
+    safe = sanitize_name(name)
+    if not _IDENTIFIER_RE.fullmatch(safe):
+        msg = "Unsafe SQLite identifier"
+        raise ValueError(msg)
+    return safe
+
+
+def _quoted_identifier(name: str) -> str:
+    return f'"{_safe_identifier(name)}"'
+
+
 def create_table_statement() -> str:
     typed_fields = [
         f'"{sanitize_name(field)}" {data_type}'
@@ -70,13 +85,35 @@ def create_table_statement() -> str:
 
 
 def _unique_index_statement(table: str, columns: list[str]) -> str:
+    safe_table = _safe_identifier(table)
     # NULLs compare as distinct in SQLite unique indexes, so index over
     # COALESCE(column, '') to make rows containing NULLs deduplicate too.
-    exprs = ", ".join(f"COALESCE(\"{column}\", '')" for column in columns)
-    return (
-        f'CREATE UNIQUE INDEX IF NOT EXISTS "idx_{table}_unique" '
-        f'ON "{table}" ({exprs});'
+    exprs = ", ".join(
+        f"COALESCE({_quoted_identifier(column)}, '')" for column in columns
     )
+    return (
+        f'CREATE UNIQUE INDEX IF NOT EXISTS "idx_{safe_table}_unique" '
+        f"ON {_quoted_identifier(safe_table)} ({exprs});"
+    )
+
+
+def _deduplicate_existing_rows(
+    conn: Connection,
+    table: str,
+    columns: Sequence[str],
+) -> None:
+    safe_table = _safe_identifier(table)
+    group_exprs = ", ".join(
+        f"COALESCE({_quoted_identifier(column)}, '')" for column in columns
+    )
+    delete_query = (
+        f"DELETE FROM {_quoted_identifier(safe_table)} "  # noqa: S608
+        f"WHERE rowid NOT IN ("
+        f"SELECT MIN(rowid) FROM {_quoted_identifier(safe_table)} "
+        f"GROUP BY {group_exprs}"
+        ");"
+    )
+    conn.execute(delete_query)
 
 
 def _create_fts(conn: Connection) -> None:
@@ -113,6 +150,7 @@ def _create_fts(conn: Connection) -> None:
 
 def create_table(conn: Connection) -> None:
     conn.execute(create_table_statement())
+    _deduplicate_existing_rows(conn, TABLE_NAME, FIELDS)
     conn.execute(_unique_index_statement(TABLE_NAME, FIELDS))
     for field in INDEXED_FIELDS:
         conn.execute(
@@ -124,16 +162,24 @@ def create_table(conn: Connection) -> None:
 
 
 def create_generic_table(conn: Connection, table: str, columns: list[str]) -> None:
-    cols = ",\n    ".join(f'"{column}" TEXT' for column in columns)
-    conn.execute(f'CREATE TABLE IF NOT EXISTS "{table}" ({cols});')
-    conn.execute(_unique_index_statement(table, columns))
+    safe_table = _safe_identifier(table)
+    safe_columns = [_safe_identifier(column) for column in columns]
+    cols = ",\n    ".join(
+        f"{_quoted_identifier(column)} TEXT" for column in safe_columns
+    )
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_quoted_identifier(safe_table)} ({cols});",
+    )
+    _deduplicate_existing_rows(conn, safe_table, safe_columns)
+    conn.execute(_unique_index_statement(safe_table, safe_columns))
     conn.commit()
 
 
 def drop_table(conn: Connection, table: str) -> None:
-    conn.execute(f'DROP TABLE IF EXISTS "{table}";')
-    if table == TABLE_NAME:
-        conn.execute(f'DROP TABLE IF EXISTS "{FTS_TABLE_NAME}";')
+    safe_table = _safe_identifier(table)
+    conn.execute(f"DROP TABLE IF EXISTS {_quoted_identifier(safe_table)};")
+    if safe_table == TABLE_NAME:
+        conn.execute(f"DROP TABLE IF EXISTS {_quoted_identifier(FTS_TABLE_NAME)};")
     conn.commit()
 
 
@@ -149,7 +195,10 @@ def insert_rows(
 ) -> int:
     """Insert rows with INSERT OR IGNORE and return how many were new."""
     placeholders = ", ".join(["?"] * column_count)
-    insert_query = f'INSERT OR IGNORE INTO "{table}" VALUES ({placeholders})'  # noqa: S608
+    insert_query = (
+        f"INSERT OR IGNORE INTO {_quoted_identifier(table)} "  # noqa: S608
+        f"VALUES ({placeholders})"
+    )
     cursor = conn.executemany(insert_query, rows)
     # rowcount counts only the statement's direct changes, unlike
     # Connection.total_changes which also counts FTS trigger writes.
@@ -183,8 +232,11 @@ def is_isbn10(value: str) -> bool:
 def get_books(conn: Connection) -> list[dict[str, str]]:
     """Return distinct ISBN-10 ASINs (print books) with their product names."""
     cursor = conn.execute(
-        f'SELECT DISTINCT "ASIN", "Product_Name" FROM "{TABLE_NAME}" '  # noqa: S608
-        'WHERE "ASIN" IS NOT NULL AND "ASIN" != \'\';',
+        f"SELECT \"ASIN\", COALESCE(MAX(NULLIF(\"Product_Name\", '')), '') "  # noqa: S608
+        f"FROM {_quoted_identifier(TABLE_NAME)} "
+        'WHERE "ASIN" IS NOT NULL AND "ASIN" != \'\' '
+        'GROUP BY "ASIN" '
+        'ORDER BY "ASIN";',
     )
     return [
         {"asin": asin, "title": title or ""}

--- a/amazon_to_sqlite/importer.py
+++ b/amazon_to_sqlite/importer.py
@@ -92,9 +92,15 @@ def is_order_history(headers: list[str]) -> bool:
     return all(f in stripped for f in db.FIELD_TYPES)
 
 
-def normalize_date(value: str) -> str:
+def _looks_like_order_history_file(csv_path: Path) -> bool:
+    return csv_path.name.lower().startswith("retail.orderhistory")
+
+
+def normalize_date(value: str) -> str | None:
     """Normalize a date string to ISO 8601; return it unchanged if unparseable."""
     text = value.strip()
+    if not text:
+        return None
     iso_candidate = text[:-1] + "+00:00" if text.endswith("Z") else text
     try:
         return datetime.fromisoformat(iso_candidate).isoformat()
@@ -105,34 +111,41 @@ def normalize_date(value: str) -> str:
             return datetime.strptime(text, fmt).isoformat()  # noqa: DTZ007
         except ValueError:
             continue
-    return value
+    return text
 
 
-def parse_money(value: str) -> float | str:
+def parse_money(value: str) -> float | str | None:
     """Parse a currency amount ("$1,234.56", "USD 12.99") to a float.
 
     Amounts are stored as REAL (floats): convenient for SUM()/ROUND() in
     queries, at the cost of binary-float representation of cents.
-    Returns the original string if it cannot be parsed.
+    Returns None if empty, or the original string if it cannot be parsed.
     """
-    cleaned = _NON_NUMERIC.sub("", value)
+    text = value.strip()
+    if not text:
+        return None
+    cleaned = _NON_NUMERIC.sub("", text)
     if not cleaned:
         return value
+    if text.startswith("(") and text.endswith(")") and not cleaned.startswith("-"):
+        cleaned = f"-{cleaned}"
     try:
         return float(cleaned)
     except ValueError:
         return value
 
 
-def parse_int(value: str) -> int | str:
+def parse_int(value: str) -> int | str | None:
+    if not value.strip():
+        return None
     try:
         return int(float(value))
-    except ValueError:
+    except (OverflowError, ValueError):
         return value
 
 
-def _converters() -> list[Callable[[str], str | float | int]]:
-    converters: list[Callable[[str], str | float | int]] = []
+def _converters() -> list[Callable[[str], str | float | int | None]]:
+    converters: list[Callable[[str], str | float | int | None]] = []
     for original_name in db.FIELD_TYPES:
         if original_name in DATE_FIELDS:
             converters.append(normalize_date)
@@ -152,7 +165,7 @@ def table_name_for(path: Path) -> str:
 def peek_table_name(csv_path: Path) -> str:
     """Determine the destination table without importing anything."""
     headers = _read_headers(csv_path)
-    if is_order_history(headers):
+    if is_order_history(headers) or _looks_like_order_history_file(csv_path):
         return db.TABLE_NAME
     return table_name_for(csv_path)
 
@@ -160,7 +173,7 @@ def peek_table_name(csv_path: Path) -> str:
 def _read_headers(csv_path: Path) -> list[str]:
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         headers = next(csv.reader(csvfile, quotechar='"'), None)
-    if headers is None:
+    if not headers:
         raise EmptyCsvError(csv_path)
     return headers
 
@@ -170,7 +183,13 @@ def expand_paths(paths: Iterable[Path]) -> list[Path]:
     expanded: list[Path] = []
     for path in paths:
         if path.is_dir():
-            expanded.extend(sorted(path.rglob("*.csv")))
+            expanded.extend(
+                sorted(
+                    candidate
+                    for candidate in path.rglob("*")
+                    if candidate.is_file() and candidate.suffix.lower() == ".csv"
+                ),
+            )
         else:
             expanded.append(path)
     return expanded
@@ -193,7 +212,7 @@ def _chunks(
 def _normalize_order_row(
     row: list[str],
     indexes: list[int],
-    converters: list[Callable[[str], str | float | int]],
+    converters: list[Callable[[str], str | float | int | None]],
     header_count: int,
 ) -> list[str | float | int | None]:
     padded = row + [""] * (header_count - len(row))
@@ -219,7 +238,7 @@ def import_order_history(
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         reader = csv.reader(csvfile, quotechar='"')
         headers = next(reader, None)
-        if headers is None:
+        if not headers:
             raise EmptyCsvError(csv_path)
         indexes, extras = validate_headers(headers)
         result.extra_columns = extras
@@ -257,7 +276,7 @@ def import_generic(
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         reader = csv.reader(csvfile, quotechar='"')
         headers = next(reader, None)
-        if headers is None:
+        if not headers:
             raise EmptyCsvError(csv_path)
         columns = _unique_columns(headers)
         db.create_generic_table(conn, table, columns)
@@ -282,11 +301,16 @@ def import_generic(
 
 def _unique_columns(headers: list[str]) -> list[str]:
     columns: list[str] = []
+    lower_columns: set[str] = set()
     for position, header in enumerate(headers):
-        name = db.sanitize_name(header.strip()) if header.strip() else f"col_{position}"
-        while name in columns:
-            name += "_"
+        base = db.sanitize_name(header.strip()) if header.strip() else f"col_{position}"
+        name = base
+        suffix = 2
+        while name.lower() in lower_columns:
+            name = f"{base}_{suffix}"
+            suffix += 1
         columns.append(name)
+        lower_columns.add(name.lower())
     return columns
 
 
@@ -299,7 +323,7 @@ def import_file(
 ) -> ImportResult:
     """Import a CSV, routing order history and other exports appropriately."""
     headers = _read_headers(csv_path)
-    if is_order_history(headers):
+    if is_order_history(headers) or _looks_like_order_history_file(csv_path):
         return import_order_history(
             conn,
             csv_path,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,11 @@ def make_row(**overrides: str) -> list[str]:
         "Gift Recipient Contact Details": "Not Available",
         "Item Serial Number": "Not Applicable",
     }
+    unknown = set(overrides) - set(HEADERS)
+    if unknown:
+        raise ValueError(
+            "Unknown order-history field override(s): " + ", ".join(sorted(unknown)),
+        )
     values.update(overrides)
     return [values[h] for h in HEADERS]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
+import csv
 import sqlite3
 from pathlib import Path
 
 import pytest
+from conftest import make_row, write_csv
 
-from amazon_to_sqlite import __version__, db
+from amazon_to_sqlite import __version__, db, importer
 from amazon_to_sqlite.__main__ import main
 
 
@@ -55,8 +57,11 @@ def test_import_directory(tmp_path: Path, orders_csv: Path):
 
 def test_import_replace(tmp_path: Path, orders_csv: Path):
     db_file = tmp_path / "amazon.db"
-    main(["import", "--quiet", str(orders_csv), "--db", str(db_file)])
-    main(["import", "--quiet", "--replace", str(orders_csv), "--db", str(db_file)])
+    assert main(["import", "--quiet", str(orders_csv), "--db", str(db_file)]) == 0
+    assert (
+        main(["import", "--quiet", "--replace", str(orders_csv), "--db", str(db_file)])
+        == 0
+    )
     conn = sqlite3.connect(db_file)
     count = conn.execute(f"SELECT COUNT(*) FROM {db.TABLE_NAME}").fetchone()[0]
     conn.close()
@@ -70,13 +75,69 @@ def test_import_missing_file(tmp_path: Path, capsys):
     assert "not found" in capsys.readouterr().err
 
 
+def test_import_empty_csv(tmp_path: Path, capsys):
+    empty = tmp_path / "empty.csv"
+    empty.write_text("", encoding="utf-8")
+    db_file = tmp_path / "amazon.db"
+    code = main(["import", str(empty), "--db", str(db_file)])
+    assert code == 1
+    assert "empty" in capsys.readouterr().err
+
+
 def test_import_bad_headers(tmp_path: Path, capsys):
-    bad = tmp_path / "bad.csv"
-    bad.write_text("", encoding="utf-8")
+    bad = tmp_path / "Retail.OrderHistory.Bad.csv"
+    bad.write_text(
+        "Website,Order ID\nAmazon.com,111-2223334-5556667\n", encoding="utf-8"
+    )
     db_file = tmp_path / "amazon.db"
     code = main(["import", str(bad), "--db", str(db_file)])
     assert code == 1
-    assert "empty" in capsys.readouterr().err
+    assert "missing expected column" in capsys.readouterr().err
+
+
+def test_import_rolls_back_failed_file(
+    tmp_path: Path,
+    orders_csv: Path,
+    capsys,
+    monkeypatch,
+):
+    bad = write_csv(
+        tmp_path / "bad.csv",
+        [make_row(**{"Order ID": "111-9999999-9999999"})],
+    )
+    db_file = tmp_path / "amazon.db"
+    real_import_file = importer.import_file
+
+    def fail_after_partial_insert(conn, csv_path, *, chunk_size=1000, progress=None):
+        if csv_path == bad:
+            db.create_table(conn)
+            partial_row = make_row(**{"Order ID": "111-9999999-9999999"})
+            db.insert_rows(conn, db.TABLE_NAME, [partial_row], len(db.FIELDS))
+            message = "malformed CSV"
+            raise csv.Error(message)
+        return real_import_file(
+            conn,
+            csv_path,
+            chunk_size=chunk_size,
+            progress=progress,
+        )
+
+    monkeypatch.setattr(
+        "amazon_to_sqlite.__main__.import_file",
+        fail_after_partial_insert,
+    )
+    code = main(["import", "--quiet", str(bad), str(orders_csv), "--db", str(db_file)])
+    assert code == 1
+    assert "malformed CSV" in capsys.readouterr().err
+    conn = sqlite3.connect(db_file)
+    count = conn.execute(f"SELECT COUNT(*) FROM {db.TABLE_NAME}").fetchone()[0]
+    partial_count = conn.execute(
+        f"SELECT COUNT(*) FROM {db.TABLE_NAME} WHERE Order_ID = ?",
+        ("111-9999999-9999999",),
+    ).fetchone()[0]
+    conn.close()
+    assert count == 2
+    assert partial_count == 0
 
 
 def test_check_formats_missing_db(tmp_path: Path, capsys):
@@ -85,17 +146,43 @@ def test_check_formats_missing_db(tmp_path: Path, capsys):
     assert "not found" in capsys.readouterr().err
 
 
-def test_check_formats_no_books(tmp_path: Path, orders_csv: Path, capsys, monkeypatch):
+def test_check_formats_bad_schema(tmp_path: Path, capsys):
+    db_file = tmp_path / "missing-table.db"
+    sqlite3.connect(db_file).close()
+    code = main(["check-formats", "--db", str(db_file)])
+    assert code == 1
+    assert "no such table" in capsys.readouterr().err
+
+
+def test_check_formats_from_db(tmp_path: Path, orders_csv: Path, capsys, monkeypatch):
     db_file = tmp_path / "amazon.db"
     calls: list[str] = []
     monkeypatch.setattr(
         "amazon_to_sqlite.__main__.check_book_formats",
         calls.append,
     )
-    main(["import", "--quiet", str(orders_csv), "--db", str(db_file)])
+    assert main(["import", "--quiet", str(orders_csv), "--db", str(db_file)]) == 0
     capsys.readouterr()
-    assert main(["check-formats", "--db", str(db_file)]) == 0
+    assert main(["check-formats", "--db", str(db_file), "--delay", "0"]) == 0
     assert calls == ["0306406152"]
+
+
+def test_check_formats_no_books(tmp_path: Path, capsys, monkeypatch):
+    db_file = tmp_path / "amazon.db"
+    no_book_csv = write_csv(
+        tmp_path / "orders.csv",
+        [make_row(**{"ASIN": "B08N5WRWNW", "Product Name": "Echo Dot"})],
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "amazon_to_sqlite.__main__.check_book_formats",
+        calls.append,
+    )
+    assert main(["import", "--quiet", str(no_book_csv), "--db", str(db_file)]) == 0
+    capsys.readouterr()
+    assert main(["check-formats", "--db", str(db_file), "--delay", "0"]) == 0
+    assert calls == []
+    assert "No print books" in capsys.readouterr().out
 
 
 def test_check_formats_explicit_asins(monkeypatch, capsys):
@@ -104,6 +191,6 @@ def test_check_formats_explicit_asins(monkeypatch, capsys):
         "amazon_to_sqlite.__main__.check_book_formats",
         calls.append,
     )
-    assert main(["check-formats", "0306406152", "080442957X"]) == 0
+    assert main(["check-formats", "--delay", "0", "0306406152", "080442957X"]) == 0
     assert calls == ["0306406152", "080442957X"]
     assert "0306406152" in capsys.readouterr().out

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -15,6 +15,7 @@ def test_sanitize_name():
     )
     assert db.sanitize_name("Order ID") == "Order_ID"
     assert db.sanitize_name("123 Fun") == "t_123_Fun"
+    assert db.sanitize_name("Café") == "Caf"
 
 
 def test_create_table_is_idempotent(conn: sqlite3.Connection):
@@ -25,6 +26,19 @@ def test_create_table_is_idempotent(conn: sqlite3.Connection):
         for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
     }
     assert db.TABLE_NAME in tables
+
+
+def test_create_table_removes_historical_duplicates(conn: sqlite3.Connection):
+    conn.execute(db.create_table_statement())
+    row = ["x"] * len(db.FIELDS)
+    placeholders = ", ".join(["?"] * len(db.FIELDS))
+    conn.executemany(
+        f"INSERT INTO {db.TABLE_NAME} VALUES ({placeholders})",
+        [row, row],
+    )
+    db.create_table(conn)
+    count = conn.execute(f"SELECT COUNT(*) FROM {db.TABLE_NAME}").fetchone()[0]
+    assert count == 1
 
 
 def test_create_table_adds_indexes_and_fts(conn: sqlite3.Connection):
@@ -67,6 +81,19 @@ def test_insert_deduplicates_rows_with_nulls(conn: sqlite3.Connection):
     assert db.insert(conn, [row]) == 0
 
 
+def test_generic_helpers_sanitize_identifiers(conn: sqlite3.Connection):
+    raw_table = 'unsafe"; DROP TABLE amazon_orders; --'
+    raw_column = 'value"; DROP TABLE amazon_orders; --'
+    safe_table = db.sanitize_name(raw_table)
+    safe_column = db.sanitize_name(raw_column)
+    db.create_generic_table(conn, raw_table, [raw_column])
+    assert db.insert_rows(conn, raw_table, [["kept"]], 1) == 1
+    value = conn.execute(
+        f'SELECT "{safe_column}" FROM "{safe_table}"',
+    ).fetchone()[0]
+    assert value == "kept"
+
+
 def test_fts_search(conn: sqlite3.Connection):
     db.create_table(conn)
     row = ["x"] * len(db.FIELDS)
@@ -93,10 +120,12 @@ def test_get_books(conn: sqlite3.Connection):
     book_row = ["x"] * len(db.FIELDS)
     book_row[db.FIELDS.index("ASIN")] = "0306406152"
     book_row[db.FIELDS.index("Product_Name")] = "A Book"
+    book_row_updated_title = list(book_row)
+    book_row_updated_title[db.FIELDS.index("Product_Name")] = "Z Book"
     gadget_row = ["y"] * len(db.FIELDS)
     gadget_row[db.FIELDS.index("ASIN")] = "B08N5WRWNW"
-    db.insert(conn, [book_row, gadget_row])
-    assert db.get_books(conn) == [{"asin": "0306406152", "title": "A Book"}]
+    db.insert(conn, [book_row, book_row_updated_title, gadget_row])
+    assert db.get_books(conn) == [{"asin": "0306406152", "title": "Z Book"}]
 
 
 def test_drop_table(conn: sqlite3.Connection):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -30,6 +30,11 @@ def test_validate_headers_extra_columns():
     assert extras == ["New Amazon Column"]
 
 
+def test_make_row_rejects_unknown_override():
+    with pytest.raises(ValueError, match="Unknown order-history field"):
+        make_row(**{"Order Id": "typo"})
+
+
 def test_normalize_date():
     assert importer.normalize_date("2023-08-12T20:23:53Z") == (
         "2023-08-12T20:23:53+00:00"
@@ -37,19 +42,28 @@ def test_normalize_date():
     assert importer.normalize_date("08/12/2023") == "2023-08-12T00:00:00"
     assert importer.normalize_date("8/2/2023 14:30:00") == "2023-08-02T14:30:00"
     assert importer.normalize_date("not a date") == "not a date"
+    assert importer.normalize_date("  not a date  ") == "not a date"
+    assert importer.normalize_date("") is None
+    assert importer.normalize_date("   ") is None
 
 
 def test_parse_money():
     assert importer.parse_money("$1,234.56") == 1234.56
     assert importer.parse_money("USD 12.99") == 12.99
     assert importer.parse_money("-3.50") == -3.50
+    assert importer.parse_money("($1.99)") == -1.99
     assert importer.parse_money("free") == "free"
+    assert importer.parse_money("") is None
+    assert importer.parse_money("   ") is None
 
 
 def test_parse_int():
     assert importer.parse_int("2") == 2
     assert importer.parse_int("2.0") == 2
     assert importer.parse_int("many") == "many"
+    assert importer.parse_int("Infinity") == "Infinity"
+    assert importer.parse_int("") is None
+    assert importer.parse_int("   ") is None
 
 
 def test_import_order_history(conn: sqlite3.Connection, orders_csv: Path):
@@ -105,6 +119,20 @@ def test_import_generic_csv(conn: sqlite3.Connection, tmp_path: Path):
     assert again.rows_inserted == 0
 
 
+def test_import_generic_case_insensitive_duplicate_headers(
+    conn: sqlite3.Connection,
+    tmp_path: Path,
+):
+    csv_path = tmp_path / "Case Headers.csv"
+    csv_path.write_text("Title,title\nSome Ebook,D01-123\n", encoding="utf-8")
+    result = importer.import_file(conn, csv_path)
+    assert result.rows_inserted == 1
+    columns = [
+        row[1] for row in conn.execute(f"PRAGMA table_info({result.table})").fetchall()
+    ]
+    assert columns == ["Title", "title_2"]
+
+
 def test_short_rows_are_padded(conn: sqlite3.Connection, tmp_path: Path):
     row = make_row()[:-3]  # drop trailing columns
     csv_path = write_csv(tmp_path / "short.csv", [row])
@@ -118,13 +146,20 @@ def test_empty_csv_raises(conn: sqlite3.Connection, tmp_path: Path):
     with pytest.raises(importer.EmptyCsvError):
         importer.import_file(conn, empty)
 
+    empty_header = tmp_path / "empty-header.csv"
+    empty_header.write_text("\r", encoding="utf-8")
+    with pytest.raises(importer.EmptyCsvError):
+        importer.import_file(conn, empty_header)
+
 
 def test_expand_paths(tmp_path: Path, orders_csv: Path):
     nested = tmp_path / "nested"
     nested.mkdir()
+    upper = nested / "A.CSV"
+    upper.write_text("A,B\n3,4\n", encoding="utf-8")
     other = nested / "b.csv"
     other.write_text("A,B\n1,2\n", encoding="utf-8")
-    assert importer.expand_paths([tmp_path]) == [orders_csv, other]
+    assert importer.expand_paths([tmp_path]) == [orders_csv, upper, other]
     assert importer.expand_paths([orders_csv]) == [orders_csv]
 
 


### PR DESCRIPTION
## Summary

Fixes the actionable review feedback from PR #4 after it was merged into `main`.

- Add per-file transaction boundaries and clean CSV/SQLite error handling for imports.
- Normalize empty parser values to `NULL`, handle integer overflow, preserve accounting-style negative money values, and detect empty CSV header rows.
- Harden SQLite helper identifier handling and remove historical duplicate rows before creating unique indexes.
- Make directory CSV discovery case-insensitive, group `check-formats` lookups by ASIN, and add request pacing.
- Pin publish workflow setup-python and require `setuptools>=61.0` for dynamic metadata.
- Update docs and add regression tests for the reviewed edge cases.

## Root Cause

The PR refactor added robust schema/indexing and routing paths, but some edge cases remained around transaction scope, malformed input, historical data migration, and CI supply-chain hardening.

## Validation

- `venv/bin/python -m ruff check amazon_to_sqlite tests`
- `venv/bin/python -m ruff format --check amazon_to_sqlite tests`
- `venv/bin/python -m mypy amazon_to_sqlite`
- `venv/bin/python -m pytest`
- `venv/bin/python -m pyroma . --min=10`
- `venv/bin/amazon-to-sqlite --version`
- `venv/bin/python -m amazon_to_sqlite --help |& grep -qi 'usage:'`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/amazon-to-sqlite/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

