### PR TITLE
[codex] Fix PR review follow-ups

### DIFF
--- a/amazon_to_sqlite/db.py
+++ b/amazon_to_sqlite/db.py
@@ -84,15 +84,32 @@ def create_table_statement() -> str:
     return f"CREATE TABLE IF NOT EXISTS {TABLE_NAME} ({fields_str});"
 
 
+def _unique_index_name(table: str) -> str:
+    safe_table = _safe_identifier(table)
+    return f"idx_{safe_table}_unique"
+
+
+def _unique_index_exists(conn: Connection, table: str) -> bool:
+    index_name = _unique_index_name(table)
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()
+        is not None
+    )
+
+
 def _unique_index_statement(table: str, columns: list[str]) -> str:
     safe_table = _safe_identifier(table)
+    index_name = _unique_index_name(safe_table)
     # NULLs compare as distinct in SQLite unique indexes, so index over
     # COALESCE(column, '') to make rows containing NULLs deduplicate too.
     exprs = ", ".join(
         f"COALESCE({_quoted_identifier(column)}, '')" for column in columns
     )
     return (
-        f'CREATE UNIQUE INDEX IF NOT EXISTS "idx_{safe_table}_unique" '
+        f"CREATE UNIQUE INDEX IF NOT EXISTS {_quoted_identifier(index_name)} "
         f"ON {_quoted_identifier(safe_table)} ({exprs});"
     )
 
@@ -150,7 +167,8 @@ def _create_fts(conn: Connection) -> None:
 
 def create_table(conn: Connection) -> None:
     conn.execute(create_table_statement())
-    _deduplicate_existing_rows(conn, TABLE_NAME, FIELDS)
+    if not _unique_index_exists(conn, TABLE_NAME):
+        _deduplicate_existing_rows(conn, TABLE_NAME, FIELDS)
     conn.execute(_unique_index_statement(TABLE_NAME, FIELDS))
     for field in INDEXED_FIELDS:
         conn.execute(
@@ -170,7 +188,8 @@ def create_generic_table(conn: Connection, table: str, columns: list[str]) -> No
     conn.execute(
         f"CREATE TABLE IF NOT EXISTS {_quoted_identifier(safe_table)} ({cols});",
     )
-    _deduplicate_existing_rows(conn, safe_table, safe_columns)
+    if not _unique_index_exists(conn, safe_table):
+        _deduplicate_existing_rows(conn, safe_table, safe_columns)
     conn.execute(_unique_index_statement(safe_table, safe_columns))
     conn.commit()
 

--- a/amazon_to_sqlite/importer.py
+++ b/amazon_to_sqlite/importer.py
@@ -170,10 +170,14 @@ def peek_table_name(csv_path: Path) -> str:
     return table_name_for(csv_path)
 
 
+def _is_blank_header_row(headers: list[str]) -> bool:
+    return not headers or all(not header.strip() for header in headers)
+
+
 def _read_headers(csv_path: Path) -> list[str]:
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         headers = next(csv.reader(csvfile, quotechar='"'), None)
-    if not headers:
+    if headers is None or _is_blank_header_row(headers):
         raise EmptyCsvError(csv_path)
     return headers
 
@@ -238,7 +242,7 @@ def import_order_history(
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         reader = csv.reader(csvfile, quotechar='"')
         headers = next(reader, None)
-        if not headers:
+        if headers is None or _is_blank_header_row(headers):
             raise EmptyCsvError(csv_path)
         indexes, extras = validate_headers(headers)
         result.extra_columns = extras
@@ -276,7 +280,7 @@ def import_generic(
     with csv_path.open(newline="", encoding="utf-8-sig") as csvfile:
         reader = csv.reader(csvfile, quotechar='"')
         headers = next(reader, None)
-        if not headers:
+        if headers is None or _is_blank_header_row(headers):
             raise EmptyCsvError(csv_path)
         columns = _unique_columns(headers)
         db.create_generic_table(conn, table, columns)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -41,6 +41,24 @@ def test_create_table_removes_historical_duplicates(conn: sqlite3.Connection):
     assert count == 1
 
 
+def test_create_table_skips_deduplication_after_unique_index_exists(
+    conn: sqlite3.Connection,
+):
+    db.create_table(conn)
+    statements: list[str] = []
+
+    conn.set_trace_callback(statements.append)
+    try:
+        db.create_table(conn)
+    finally:
+        conn.set_trace_callback(None)
+
+    assert not any(
+        statement.lstrip().upper().startswith("DELETE FROM")
+        for statement in statements
+    )
+
+
 def test_create_table_adds_indexes_and_fts(conn: sqlite3.Connection):
     db.create_table(conn)
     indexes = {
@@ -92,6 +110,24 @@ def test_generic_helpers_sanitize_identifiers(conn: sqlite3.Connection):
         f'SELECT "{safe_column}" FROM "{safe_table}"',
     ).fetchone()[0]
     assert value == "kept"
+
+
+def test_create_generic_table_skips_deduplication_after_unique_index_exists(
+    conn: sqlite3.Connection,
+):
+    db.create_generic_table(conn, "generic", ["A", "B"])
+    statements: list[str] = []
+
+    conn.set_trace_callback(statements.append)
+    try:
+        db.create_generic_table(conn, "generic", ["A", "B"])
+    finally:
+        conn.set_trace_callback(None)
+
+    assert not any(
+        statement.lstrip().upper().startswith("DELETE FROM")
+        for statement in statements
+    )
 
 
 def test_fts_search(conn: sqlite3.Connection):

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -151,6 +151,11 @@ def test_empty_csv_raises(conn: sqlite3.Connection, tmp_path: Path):
     with pytest.raises(importer.EmptyCsvError):
         importer.import_file(conn, empty_header)
 
+    delimiter_header = tmp_path / "delimiter-header.csv"
+    delimiter_header.write_text(" ,\t,\n1,2,3\n", encoding="utf-8")
+    with pytest.raises(importer.EmptyCsvError):
+        importer.import_file(conn, delimiter_header)
+
 
 def test_expand_paths(tmp_path: Path, orders_csv: Path):
     nested = tmp_path / "nested"


### PR DESCRIPTION
## Summary

- Skip historical row deduplication once the table unique index already exists.
- Reject delimiter-only or whitespace-only CSV header rows as empty headers.
- Add regression tests for both behaviors.

## Why

PR review feedback found two follow-up issues: table creation was still running the expensive duplicate cleanup query on every import after the unique index existed, and CSV files whose first row only contained delimiters or whitespace could be treated as having headers.

## Impact

Repeated imports avoid unnecessary full-table delete scans, while invalid empty-header CSVs fail earlier and consistently across peek, order-history, and generic import paths.

## Validation

- `uv run --extra lint pytest`
- `uv run --extra lint ruff check`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/amazon-to-sqlite/pull/8?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

