### PR TITLE
[codex] Fix PR 8 review follow-ups

### DIFF
--- a/amazon_to_sqlite/db.py
+++ b/amazon_to_sqlite/db.py
@@ -93,7 +93,8 @@ def _unique_index_exists(conn: Connection, table: str) -> bool:
     index_name = _unique_index_name(table)
     return (
         conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?",
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='index' AND name=? COLLATE NOCASE",
             (index_name,),
         ).fetchone()
         is not None
@@ -102,7 +103,7 @@ def _unique_index_exists(conn: Connection, table: str) -> bool:
 
 def _unique_index_statement(table: str, columns: list[str]) -> str:
     safe_table = _safe_identifier(table)
-    index_name = _unique_index_name(safe_table)
+    index_name = _unique_index_name(table)
     # NULLs compare as distinct in SQLite unique indexes, so index over
     # COALESCE(column, '') to make rows containing NULLs deduplicate too.
     exprs = ", ".join(

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -130,6 +130,24 @@ def test_create_generic_table_skips_deduplication_after_unique_index_exists(
     )
 
 
+def test_create_generic_table_finds_unique_index_with_different_case(
+    conn: sqlite3.Connection,
+):
+    db.create_generic_table(conn, "MixedCase", ["A", "B"])
+    statements: list[str] = []
+
+    conn.set_trace_callback(statements.append)
+    try:
+        db.create_generic_table(conn, "mixedcase", ["A", "B"])
+    finally:
+        conn.set_trace_callback(None)
+
+    assert not any(
+        statement.lstrip().upper().startswith("DELETE FROM")
+        for statement in statements
+    )
+
+
 def test_fts_search(conn: sqlite3.Connection):
     db.create_table(conn)
     row = ["x"] * len(db.FIELDS)


### PR DESCRIPTION
## What changed

- Make the SQLite `sqlite_master` unique-index lookup case-insensitive with `COLLATE NOCASE`.
- Avoid passing an already sanitized table name back through `_unique_index_name`.
- Add regression coverage for recreating a generic table with different casing.

## Why

PR #8 review feedback pointed out that SQLite treats index names case-insensitively, but `sqlite_master.name` comparisons default to binary collation. The previous lookup could miss an existing unique index when table-name casing differed, causing redundant deduplication work.

## Validation

- `.venv/bin/python -m pytest` -> 49 passed
- `.venv/bin/python -m ruff check .` -> passed
- `.venv/bin/python -m mypy amazon_to_sqlite tests` -> passed


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/hbmartin/amazon-to-sqlite/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

